### PR TITLE
feat: allow all RPC provider

### DIFF
--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -150,6 +150,6 @@ export function getWeb3Provider(
         return key;
     };
 
-    const apiKey = readKey('ALCHEMY_KEY');
-    return new ethers.providers.AlchemyProvider('Mainnet', { apiKey });
+    const rpc = readKey('RPC');
+    return new ethers.providers.JsonRpcProvider(rpc);
 }


### PR DESCRIPTION
Using the alchemy provider locks us in with alchemy. But if we use the `JsonRpcProvider` we can use most RPC providers incl. a local node. 

To use alchemy you just need to put `RPC="https://eth-mainnet.g.alchemy.com/v2/<API_Key>"` in `.env`
