### PR TITLE
Let user sign message directly after connect wallet and start Sign In process immediately if a specific query string param was provided

### DIFF
--- a/packages/messenger-widget/src/components/SignIn/SignIn.tsx
+++ b/packages/messenger-widget/src/components/SignIn/SignIn.tsx
@@ -51,7 +51,7 @@ export function SignIn() {
         openConnectModal && openConnectModal();
     };
 
-    // useEffect is needed to give sometime to the components to be fully rendered first to avoid exceptions inside `changeSignInButtonStyle` function.
+    // useEffect is needed to give some time to the components to be fully rendered first to avoid exceptions inside `changeSignInButtonStyle` function.
     useEffect(() => {
         if (shouldSignInDirectly) {
             handleConnectWithWallet();

--- a/packages/messenger-widget/src/hooks/auth/useAuth.ts
+++ b/packages/messenger-widget/src/hooks/auth/useAuth.ts
@@ -92,7 +92,7 @@ export const useAuth = () => {
         setCleanSignInRequested(true);
     };
 
-    // useEffect is needed to give sometime to the wallet connect variables to be initialized.
+    // useEffect is needed to give some time to the wallet connect variables to be initialized.
     // without utilizing it the variable `walletClient` would be undefined.
     useEffect(() => {
         (async () => {


### PR DESCRIPTION
Hello,

Some users, especially who are new to crypto, gave a feedback about getting confused because of the need to click 2 times to Sign In: The first click to Connect Wallet + Another click to Sing a Message.
Additionally, when the user follow the link from the landing page, he is still needs to click additional 2 times to finally sign in.
This small MR enhances the UX by:
- Letting the user signs the message directly after connecting the wallet, without the need for another button click. 
- Start the Sign In process immediately, if a specific query string param was provided. So, in the landing page, the url of the app would be like: `app.domain.com?sign-in-directly=true`, or for short `app.domain.com?sid=1`, and the user would not need to press the Sign In button after he already pressed 'Lunch App' for example. In this case, the total of 3 clicks would be reduced to 1.

We plan on implementing those changes at https://highcoiny.com. And we hope it will help other service providers. So, please, try it and let us know if you have any suggestions. 

Thanks,