### PR TITLE
create cronjob for certbot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,3 +164,8 @@ jobs:
               run: |
                   ssh -i ./ssh-key app@${{ vars.HOST_DOMAIN }} "\
                   cd dm3 && docker compose --env-file .env up -d && docker system prune -af"
+            - name: Create cronjob for certbot
+              run: |
+                  ssh -i ./ssh-key root@${{ vars.HOST_DOMAIN }} "\
+                  (crontab -l 2>/dev/null | grep -q 'certbot renew --quiet' || \
+                  (crontab -l 2>/dev/null; echo '0 0 * * * certbot renew --quiet') | crontab -)"


### PR DESCRIPTION
closes #841 

restarts certbot every night so it can renew certificates if required.

To test if it works:
1. deploy
2. have a restful night of sleep
3. run `docker logs certbot --timestamps` and use the logs to verify that certbot was indeed started at night. `docker container ls -a` could provide similar information.